### PR TITLE
update plugin for hapi 8.0.0 api

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ Example:
 ```
 // Route Config
 var about = {
-    handler: function (request) {
-        request.reply.view('about');
+    handler: function (request, reply) {
+        reply.view('about');
     },
     app : {
         name: 'about'
@@ -33,7 +33,7 @@ routes = [
     }
 ]
 
-server.addRoutes(routes);
+server.route(routes);
 ```
 Based on the example above you now have access to `path.about` in your view templates, and will print out the routes path `/about`.
 

--- a/index.js
+++ b/index.js
@@ -22,6 +22,8 @@ exports.register = function (server, options, next) {
             // Get length of current route table
             var checkRoutingLength =  Object.keys(checkRoutingTable);
 
+            // Initialize if context is not defined
+            response.source.context = response.source.context || {};
             // Check to see if the current route table has any new routes since plugin loaded
             if (checkRoutingLength > routingLength) {
                 // If new routes then update routingTableLength and the routingTable

--- a/index.js
+++ b/index.js
@@ -1,4 +1,6 @@
-exports.register = function (plugin, options, next) {
+/*jslint node: true */
+
+exports.register = function (server, options, next) {
     // Start the plugin routing table
     var routingTable = {};
     // Set length of routing table for checking later if new routes get added.
@@ -8,7 +10,7 @@ exports.register = function (plugin, options, next) {
     var namedRoutes = {};
 
     // Hook onto the 'onPostHandler'
-    plugin.ext('onPostHandler', function (request, next) {
+    server.ext('onPostHandler', function (request, reply) {
         // Get the response object
         var response = request.response;
 
@@ -16,7 +18,7 @@ exports.register = function (plugin, options, next) {
         if (response.variety === 'view') {
 
             // Get current routing table
-            var checkRoutingTable = request.server.table();
+            var checkRoutingTable = request.connection.table();
             // Get length of current route table
             var checkRoutingLength =  Object.keys(checkRoutingTable);
 
@@ -32,11 +34,11 @@ exports.register = function (plugin, options, next) {
                 // Loop over the routingTable
                 for(var item in routingTable){
                     //  Look for any routes with app.name defined in the config object
-                    if(typeof routingTable[item].settings.app.name != 'undefined'){
+                    if(typeof routingTable[item].settings.app.name !== 'undefined') {
                         // Get the route name from the config object and assign it to routeName
                         var routeName = routingTable[item].settings.app.name;
                         // Get the route path from the config object, remove path wildcard, and assign it to routePath
-                        var routePath = routingTable[item].settings.path.replace(/{(.*?)}/g, "");
+                        var routePath = routingTable[item].path.replace(/{(.*?)}/g, '');
 
                         // Put the current route and path being looped over into the view layer variable path
                         response.source.context.path[routeName] = routePath;
@@ -48,11 +50,11 @@ exports.register = function (plugin, options, next) {
                 response.source.context.path = namedRoutes;
             }
         }
-        return next();
+        return reply.continue();
     });
     return next();
 };
 
 exports.register.attributes = {
-    pkg: require("./package.json")
+    pkg: require('./package.json')
 };


### PR DESCRIPTION
`onPostHandler` callback should return `reply.continue()` instead of calling `next()` callback

Should use connection's routing table ( i.e. `request.connection.table()` ) instead of server's ( `request.server.table()` ). 
From hapi 8.0.0 `request.server.table()` will return array of all connections' routing table which breaks plugin's functionality
